### PR TITLE
Fix delayed updating of overview

### DIFF
--- a/src/hamster-lite
+++ b/src/hamster-lite
@@ -108,7 +108,6 @@ class HamsterClient(object):
             return
 
         fact = Fact.parse(' '.join(args))
-        print('new fact:', fact)
         fact.start_time = fact.start_time or stuff.hamster_now()
 
         self.storage.add_fact(fact)

--- a/src/hamster_lite/lib/configuration.py
+++ b/src/hamster_lite/lib/configuration.py
@@ -35,7 +35,7 @@ class Singleton(object):
 
 class ConfStore(Singleton):
     """
-    Settings implementation which stores settings as json string in hamster.db
+    Settings implementation which stores settings as simple json string
     """
     DEFAULTS = {
         'day_start_minutes' : 5 * 60 + 30,  # Virtual day start (5:30AM)

--- a/src/hamster_lite/widgets/facttree.py
+++ b/src/hamster_lite/widgets/facttree.py
@@ -4,7 +4,7 @@
 
 # This file is part of Hamster-lite.
 
-# Project Hamster is free software: you can redistribute it and/or modify
+# Hamster-lite is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 
 # You should have received a copy of the GNU General Public License
-# along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
+# along with Hamster-lite.  If not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
@@ -68,7 +68,7 @@ class FactTree(gtk.ScrolledWindow):
         model, treeiter = selection.get_selected()
         if treeiter:
             self.current_fact = self.facts[model[treeiter][-1]]
-            print(f"Fact selected: {str(self.current_fact)}")
+            #log.debug(f"Fact selected: {str(self.current_fact)}")
         else:
             self.current_fact = None
 
@@ -100,6 +100,5 @@ class FactTree(gtk.ScrolledWindow):
             time = format_duration(
                 (fact.end_time or hamster_now()) - fact.start_time)
             self.store.append([date, start_end, activity, time, idx])
-            #print(dir(self.treestore[citer][0]))
         self.treeview.expand_all()
         self.treeview.show()


### PR DESCRIPTION
The facts-changed signalling has been broken ever since the removal of DBus and client.py. As a poor substitute, changes to hamster-lite.db were monitored and this resulted in an awkward short delay before the overview was updated. Here the facts-changed signal is fired by the storage DB module and the file monitoring has been removed.