### PR TITLE
Improve formatting of activities in overview.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,7 +1,8 @@
 =============
 Version 0.1.3
 =============
-* Fixed bug in date adustment from edit window.
+* Fixed bug in date adustment from edit window (#16).
+* Improved formatting of activities in overview (#18).
 
 =============
 Version 0.1.2

--- a/src/hamster-lite
+++ b/src/hamster-lite
@@ -32,7 +32,7 @@ import datetime as dt
 import hamster_lite
 from hamster_lite import reports
 from hamster_lite import logger as hamster_logger
-from hamster_lite.lib import default_logger, Fact, stuff, DATE_FMT
+from hamster_lite.lib import default_logger, Fact, stuff, DATE_FMT, word_wrap
 from hamster_lite.lib.runtime import dialogs, runtime
 from hamster_lite.main import HamsterLite
 import hamster_lite.storage as db
@@ -214,7 +214,7 @@ class HamsterClient(object):
             print(fact_line.format(**pretty_fact))
 
             if pretty_fact['description']:
-                for line in stuff.word_wrap(pretty_fact['description'], 76):
+                for line in word_wrap(pretty_fact['description'], 76):
                     print("    {}".format(line))
 
             if pretty_fact['tags']:
@@ -229,7 +229,7 @@ class HamsterClient(object):
             cats.append("{}: {}".format(cat, stuff.format_duration(duration)))
             total_duration += duration
 
-        for line in stuff.word_wrap(", ".join(cats), 80):
+        for line in word_wrap(", ".join(cats), 80):
             print(line)
         print("Total: ", stuff.format_duration(total_duration))
 

--- a/src/hamster_lite/lib/__init__.py
+++ b/src/hamster_lite/lib/__init__.py
@@ -13,6 +13,7 @@ from hamster_lite.lib.stuff import (
     format_duration,
     escape_pango,
     hamster_now,
+    word_wrap,
 )
 
 

--- a/src/hamster_lite/widgets/facttree.py
+++ b/src/hamster_lite/widgets/facttree.py
@@ -22,6 +22,7 @@ from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject
 
 from hamster_lite.lib import hamster_now, format_duration, escape_pango
+from hamster_lite.lib import word_wrap
 
 
 def small(text):
@@ -94,9 +95,11 @@ class FactTree(gtk.ScrolledWindow):
             if fact.category:
                 activity += ' - ' + escape_pango(fact.category)
             if fact.description:
-                activity += '\n' + small(fact.description)
+                activity += ', ' + fact.description
+            activity = '\n'.join(word_wrap(activity, 72))
             if fact.tags:
-                activity += '\n' + small('Tags: ' + ', '.join(fact.tags))
+                activity += ' ' + ', '.join(
+                    ['#' + tag for tag in fact.tags])
             time = format_duration(
                 (fact.end_time or hamster_now()) - fact.start_time)
             self.store.append([date, start_end, activity, time, idx])


### PR DESCRIPTION
Use word_wrap to limit the line length and hence avoid very wide
overview windows, especially with lengthy descriptions or numerous
tags.